### PR TITLE
Set up PNPM workspace for web and mobile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,5 @@ cython_debug/
 #  refer to https://docs.cursor.com/context/ignore-files
 .cursorignore
 .cursorindexingignore
+
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
-# RevHC
+# RevHC Monorepo
+
+This repository contains a PNPM workspace with two applications:
+
+- `apps/web` - A Vite + React application.
+- `apps/mobile` - A React Native application using Expo.
+
+## Getting started
+
+Ensure you have [pnpm](https://pnpm.io/) installed. Then run:
+
+```bash
+pnpm install
+```
+
+Use the following scripts to start the applications:
+
+```bash
+pnpm --filter web dev
+pnpm --filter mobile start
+```

--- a/apps/mobile/App.js
+++ b/apps/mobile/App.js
@@ -1,0 +1,12 @@
+import { Text, View } from 'react-native'
+import { registerRootComponent } from 'expo'
+
+function App() {
+  return (
+    <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center' }}>
+      <Text>Hello Mobile</Text>
+    </View>
+  )
+}
+
+registerRootComponent(App)

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "mobile",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "start": "expo start",
+    "android": "expo start --android",
+    "ios": "expo start --ios",
+    "web": "expo start --web"
+  },
+  "dependencies": {
+    "expo": "^48.0.0",
+    "react": "^18.2.0",
+    "react-native": "^0.71.0"
+  }
+}

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>React Web</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "web",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vitejs/plugin-react": "^4.0.0",
+    "vite": "^4.1.0"
+  }
+}

--- a/apps/web/src/App.jsx
+++ b/apps/web/src/App.jsx
@@ -1,0 +1,5 @@
+export default function App() {
+  return (
+    <h1>Hello Web</h1>
+  )
+}

--- a/apps/web/src/main.jsx
+++ b/apps/web/src/main.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+
+createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/apps/web/vite.config.js
+++ b/apps/web/vite.config.js
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+})

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "revhc-monorepo",
+  "private": true,
+  "version": "1.0.0",
+  "workspaces": ["apps/*"],
+  "scripts": {
+    "install": "pnpm install --recursive"
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,9 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+packages:
+  - 'apps/*'


### PR DESCRIPTION
## Summary
- add PNPM workspace with `apps/web` and `apps/mobile`
- scaffold Vite React app
- scaffold Expo React Native app
- document usage in README

## Testing
- `pnpm install` *(fails: GET https://registry.npmjs.org/@vitejs%2Fplugin-react - 403)*

------
https://chatgpt.com/codex/tasks/task_e_684785bf4d148329800c374292804903