### PR TITLE
Add TanStack DB and Store setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,11 @@ Use the following scripts to start the applications:
 pnpm --filter web dev
 pnpm --filter mobile start
 ```
+
+## State management and storage
+
+The web application uses [TanStack Store](https://tanstack.com/store) for client
+side state management and [TanStack DB](https://tanstack.com/db) for local
+storage. An initial schema defines a `users` table to keep track of patients and
+healthcare providers and their roles. Utility helpers in `src/store` provide a
+simple API to update and read the current user.

--- a/apps/web/README.md
+++ b/apps/web/README.md
@@ -52,3 +52,6 @@ export default tseslint.config({
   },
 })
 ```
+
+## TanStack Store and DB
+This app uses TanStack Store for local state and TanStack DB for persisting users and roles.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,10 @@
   },
   "dependencies": {
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "@tanstack/store": "latest",
+    "@tanstack/react-store": "latest",
+    "@tanstack/db": "latest"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,9 +2,11 @@ import { useState } from 'react'
 import reactLogo from './assets/react.svg'
 import viteLogo from '/vite.svg'
 import './App.css'
+import { useCurrentUser, setCurrentUser } from './store/userStore'
 
 function App() {
   const [count, setCount] = useState(0)
+  const currentUser = useCurrentUser()
 
   return (
     <>
@@ -24,7 +26,27 @@ function App() {
         <p>
           Edit <code>src/App.tsx</code> and save to test HMR
         </p>
+        <div style={{ marginTop: '1rem' }}>
+          <button
+            onClick={() =>
+              setCurrentUser({ id: '1', name: 'Jane Doe', role: 'patient' })
+            }
+          >
+            Set Patient User
+          </button>
+          <button
+            onClick={() =>
+              setCurrentUser({ id: '2', name: 'Dr. Smith', role: 'provider' })
+            }
+            style={{ marginLeft: '0.5rem' }}
+          >
+            Set Provider User
+          </button>
+        </div>
       </div>
+      {currentUser && (
+        <p className="read-the-docs">Current User: {currentUser.name}</p>
+      )}
       <p className="read-the-docs">
         Click on the Vite and React logos to learn more
       </p>

--- a/apps/web/src/db.ts
+++ b/apps/web/src/db.ts
@@ -1,0 +1,17 @@
+import { createDatabase, createTable } from '@tanstack/db'
+
+export type Role = 'patient' | 'provider'
+
+export interface User {
+  id: string
+  name: string
+  role: Role
+}
+
+export const UsersTable = createTable<User>()
+  .setName('users')
+  .setPrimaryKey('id')
+
+export const db = createDatabase({
+  users: UsersTable,
+})

--- a/apps/web/src/store/userStore.ts
+++ b/apps/web/src/store/userStore.ts
@@ -1,0 +1,22 @@
+import { Store } from '@tanstack/store'
+import { useStore } from '@tanstack/react-store'
+import type { User } from '../db'
+
+export interface AppState {
+  currentUser?: User
+  users: Record<string, User>
+}
+
+export const store = new Store<AppState>({
+  currentUser: undefined,
+  users: {},
+})
+
+export const setCurrentUser = (user: User) => {
+  store.setState((s) => {
+    s.currentUser = user
+    s.users[user.id] = user
+  })
+}
+
+export const useCurrentUser = () => useStore(store, (s) => s.currentUser)


### PR DESCRIPTION
## Summary
- set up TanStack DB schema with a `users` table
- add TanStack Store for state management
- wire store into the sample web app
- document new tools

## Testing
- `pnpm lint` *(fails: Could not find turbo.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847927bf75c8329bb7502aba910f614