### PR TITLE
Add better-auth integration for web app

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,8 @@
     "tailwind-merge": "^1.14.0",
     "@tanstack/store": "latest",
     "@tanstack/react-store": "latest",
-    "@tanstack/db": "latest"
+    "@tanstack/db": "latest",
+    "better-auth": "^0.0.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,5 @@
 import { useState } from 'react'
 import { Button } from '@/components/ui/button'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
 import './App.css'
 import { useCurrentUser, setCurrentUser } from './store/userStore'
 

--- a/apps/web/src/components/sign-in.tsx
+++ b/apps/web/src/components/sign-in.tsx
@@ -1,0 +1,299 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Loader2, Key } from 'lucide-react'
+import { signIn } from '@/lib/auth-client'
+import { cn } from '@/lib/utils'
+
+export default function SignIn() {
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [loading, setLoading] = useState(false)
+  const [rememberMe, setRememberMe] = useState(false)
+
+  return (
+    <Card className="max-w-md">
+      <CardHeader>
+        <CardTitle className="text-lg md:text-xl">Sign In</CardTitle>
+        <CardDescription className="text-xs md:text-sm">
+          Enter your email below to login to your account
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-4">
+          <div className="grid gap-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="m@example.com"
+              required
+              onChange={(e) => {
+                setEmail(e.target.value)
+              }}
+              value={email}
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <div className="flex items-center">
+              <Label htmlFor="password">Password</Label>
+              <a href="#" className="ml-auto inline-block text-sm underline">
+                Forgot your password?
+              </a>
+            </div>
+
+            <Input
+              id="password"
+              type="password"
+              placeholder="password"
+              autoComplete="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Checkbox
+              id="remember"
+              onClick={() => {
+                setRememberMe(!rememberMe)
+              }}
+            />
+            <Label htmlFor="remember">Remember me</Label>
+          </div>
+
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={loading}
+            onClick={async () => {
+              await signIn.email(
+                {
+                  email,
+                  password,
+                },
+                {
+                  onRequest: () => {
+                    setLoading(true)
+                  },
+                  onResponse: () => {
+                    setLoading(false)
+                  },
+                }
+              )
+            }}
+          >
+            {loading ? (
+              <Loader2 size={16} className="animate-spin" />
+            ) : (
+              <p>Login</p>
+            )}
+          </Button>
+
+          <Button
+            variant="secondary"
+            disabled={loading}
+            className="gap-2"
+            onClick={async () => {
+              await signIn.passkey(
+                {
+                  onRequest: () => {
+                    setLoading(true)
+                  },
+                  onResponse: () => {
+                    setLoading(false)
+                  },
+                }
+              )
+            }}
+          >
+            <Key size={16} />
+            Sign-in with Passkey
+          </Button>
+
+          <div className={cn('w-full gap-2 flex items-center', 'justify-between flex-wrap')}>
+            <Button
+              variant="outline"
+              className="flex-grow"
+              disabled={loading}
+              onClick={async () => {
+                await signIn.social(
+                  {
+                    provider: 'google',
+                    callbackURL: '/dashboard',
+                  },
+                  {
+                    onRequest: () => {
+                      setLoading(true)
+                    },
+                    onResponse: () => {
+                      setLoading(false)
+                    },
+                  }
+                )
+              }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="0.98em" height="1em" viewBox="0 0 256 262">
+                <path fill="#4285F4" d="M255.878 133.451c0-10.734-.871-18.567-2.756-26.69H130.55v48.448h71.947c-1.45 12.04-9.283 30.172-26.69 42.356l-.244 1.622l38.755 30.023l2.685.268c24.659-22.774 38.875-56.282 38.875-96.027"/>
+                <path fill="#34A853" d="M130.55 261.1c35.248 0 64.839-11.605 86.453-31.622l-41.196-31.913c-11.024 7.688-25.82 13.055-45.257 13.055c-34.523 0-63.824-22.773-74.269-54.25l-1.531.13l-40.298 31.187l-.527 1.465C35.393 231.798 79.49 261.1 130.55 261.1"/>
+                <path fill="#FBBC05" d="M56.281 156.37c-2.756-8.123-4.351-16.827-4.351-25.82c0-8.994 1.595-17.697 4.206-25.82l-.073-1.73L15.26 71.312l-1.335.635C5.077 89.644 0 109.517 0 130.55s5.077 40.905 13.925 58.602z"/>
+                <path fill="#EB4335" d="M130.55 50.479c24.514 0 41.05 10.589 50.479 19.438l36.844-35.974C195.245 12.91 165.798 0 130.55 0C79.49 0 35.393 29.301 13.925 71.947l42.211 32.783c10.59-31.477 39.891-54.251 74.414-54.251"/>
+              </svg>
+            </Button>
+            <Button
+              variant="outline"
+              className="flex-grow"
+              disabled={loading}
+              onClick={async () => {
+                await signIn.social(
+                  {
+                    provider: 'github',
+                    callbackURL: '/dashboard',
+                  },
+                  {
+                    onRequest: () => {
+                      setLoading(true)
+                    },
+                    onResponse: () => {
+                      setLoading(false)
+                    },
+                  }
+                )
+              }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
+                <path fill="currentColor" d="M12 2A10 10 0 0 0 2 12c0 4.42 2.87 8.17 6.84 9.5c.5.08.66-.23.66-.5v-1.69c-2.77.6-3.36-1.34-3.36-1.34c-.46-1.16-1.11-1.47-1.11-1.47c-.91-.62.07-.6.07-.6c1 .07 1.53 1.03 1.53 1.03c.87 1.52 2.34 1.07 2.91.83c.09-.65.35-1.09.63-1.34c-2.22-.25-4.55-1.11-4.55-4.92c0-1.11.38-2 1.03-2.71c-.1-.25-.45-1.29.1-2.64c0 0 .84-.27 2.75 1.02c.79-.22 1.65-.33 2.5-.33s1.71.11 2.5.33c1.91-1.29 2.75-1.02 2.75-1.02c.55 1.35.2 2.39.1 2.64c.65.71 1.03 1.6 1.03 2.71c0 3.82-2.34 4.66-4.57 4.91c.36.31.69.92.69 1.85V21c0 .27.16.59.67.5C19.14 20.16 22 16.42 22 12A10 10 0 0 0 12 2"/>
+              </svg>
+            </Button>
+            <Button
+              variant="outline"
+              className="flex-grow"
+              disabled={loading}
+              onClick={async () => {
+                await signIn.social(
+                  {
+                    provider: 'apple',
+                    callbackURL: '/dashboard',
+                  },
+                  {
+                    onRequest: () => {
+                      setLoading(true)
+                    },
+                    onResponse: () => {
+                      setLoading(false)
+                    },
+                  }
+                )
+              }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
+                <path fill="currentColor" d="M17.05 20.28c-.98.95-2.05.8-3.08.35c-1.09-.46-2.09-.48-3.24 0c-1.44.62-2.2.44-3.06-.35C2.79 15.25 3.51 7.59 9.05 7.31c1.35.07 2.29.74 3.08.8c1.18-.24 2.31-.93 3.57-.84c1.51.12 2.65.72 3.4 1.8c-3.12 1.87-2.38 5.98.48 7.13c-.57 1.5-1.31 2.99-2.54 4.09zM12.03 7.25c-.15-2.23 1.66-4.07 3.74-4.25c.29 2.58-2.34 4.5-3.74 4.25"/>
+              </svg>
+            </Button>
+            <Button
+              variant="outline"
+              className="flex-grow"
+              disabled={loading}
+              onClick={async () => {
+                await signIn.social(
+                  {
+                    provider: 'twitter',
+                    callbackURL: '/dashboard',
+                  },
+                  {
+                    onRequest: () => {
+                      setLoading(true)
+                    },
+                    onResponse: () => {
+                      setLoading(false)
+                    },
+                  }
+                )
+              }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="1.2em" height="1.2em" viewBox="0 0 448 512"><path fill="currentColor" d="M64 32C28.7 32 0 60.7 0 96v320c0 35.3 28.7 64 64 64h320c35.3 0 64-28.7 64-64V96c0-35.3-28.7-64-64-64zm297.1 84L257.3 234.6L379.4 396h-95.6L209 298.1L123.3 396H75.8l111-126.9L69.7 116h98l67.7 89.5l78.2-89.5zm-37.8 251.6L153.4 142.9h-28.3l171.8 224.7h26.3z"/></svg>
+            </Button>
+            <Button
+              variant="outline"
+              className="flex-grow"
+              disabled={loading}
+              onClick={async () => {
+                await signIn.social(
+                  {
+                    provider: 'microsoft',
+                    callbackURL: '/dashboard',
+                  },
+                  {
+                    onRequest: () => {
+                      setLoading(true)
+                    },
+                    onResponse: () => {
+                      setLoading(false)
+                    },
+                  }
+                )
+              }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24"><path fill="currentColor" d="M2 3h9v9H2zm9 19H2v-9h9zM21 3v9h-9V3zm0 19h-9v-9h9z"/></svg>
+            </Button>
+            <Button
+              variant="outline"
+              className="flex-grow"
+              disabled={loading}
+              onClick={async () => {
+                await signIn.social(
+                  {
+                    provider: 'linkedin',
+                    callbackURL: '/dashboard',
+                  },
+                  {
+                    onRequest: () => {
+                      setLoading(true)
+                    },
+                    onResponse: () => {
+                      setLoading(false)
+                    },
+                  }
+                )
+              }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
+                <path fill="currentColor" d="M19 3a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2zm-.5 15.5v-5.3a3.26 3.26 0 0 0-3.26-3.26c-.85 0-1.84.52-2.32 1.3v-1.11h-2.79v8.37h2.79v-4.93c0-.77.62-1.4 1.39-1.4a1.4 1.4 0 0 1 1.4 1.4v4.93zM6.88 8.56a1.68 1.68 0 0 0 1.68-1.68c0-.93-.75-1.69-1.68-1.69a1.69 1.69 0 0 0-1.69 1.69c0 .93.76 1.68 1.69 1.68m1.39 9.94v-8.37H5.5v8.37z"/>
+              </svg>
+            </Button>
+            <Button
+              variant="outline"
+              className="flex-grow"
+              disabled={loading}
+              onClick={async () => {
+                await signIn.social(
+                  {
+                    provider: 'facebook',
+                    callbackURL: '/dashboard',
+                  },
+                  {
+                    onRequest: () => {
+                      setLoading(true)
+                    },
+                    onResponse: () => {
+                      setLoading(false)
+                    },
+                  }
+                )
+              }}
+            >
+              <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 24 24">
+                <path d="M20 3H4a1 1 0 0 0-1 1v16a1 1 0 0 0 1 1h8.615v-6.96h-2.338v-2.725h2.338v-2c0-2.325 1.42-3.592 3.5-3.592c.699-.002 1.399.034 2.095.107v2.42h-1.435c-1.128 0-1.348.538-1.348 1.325v1.735h2.697l-.35 2.725h-2.348V21H20a1 1 0 0 0 1-1V4a1 1 0 0 0-1-1z" fill="currentColor"/>
+              </svg>
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+      <CardFooter />
+    </Card>
+  )
+}

--- a/apps/web/src/components/sign-up.tsx
+++ b/apps/web/src/components/sign-up.tsx
@@ -1,0 +1,163 @@
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Loader2, X } from 'lucide-react'
+import { signUp } from '@/lib/auth-client'
+
+export default function SignUp() {
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [passwordConfirmation, setPasswordConfirmation] = useState('')
+  const [image, setImage] = useState<File | null>(null)
+  const [imagePreview, setImagePreview] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  const handleImageChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0]
+    if (file) {
+      setImage(file)
+      const reader = new FileReader()
+      reader.onloadend = () => {
+        setImagePreview(reader.result as string)
+      }
+      reader.readAsDataURL(file)
+    }
+  }
+
+  return (
+    <Card className="z-50 rounded-md rounded-t-none max-w-md">
+      <CardHeader>
+        <CardTitle className="text-lg md:text-xl">Sign Up</CardTitle>
+        <CardDescription className="text-xs md:text-sm">
+          Enter your information to create an account
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid gap-4">
+          <div className="grid grid-cols-2 gap-4">
+            <div className="grid gap-2">
+              <Label htmlFor="first-name">First name</Label>
+              <Input
+                id="first-name"
+                placeholder="Max"
+                required
+                onChange={(e) => {
+                  setFirstName(e.target.value)
+                }}
+                value={firstName}
+              />
+            </div>
+            <div className="grid gap-2">
+              <Label htmlFor="last-name">Last name</Label>
+              <Input
+                id="last-name"
+                placeholder="Robinson"
+                required
+                onChange={(e) => {
+                  setLastName(e.target.value)
+                }}
+                value={lastName}
+              />
+            </div>
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="email">Email</Label>
+            <Input
+              id="email"
+              type="email"
+              placeholder="m@example.com"
+              required
+              onChange={(e) => {
+                setEmail(e.target.value)
+              }}
+              value={email}
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="password">Password</Label>
+            <Input
+              id="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              autoComplete="new-password"
+              placeholder="Password"
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="password_confirmation">Confirm Password</Label>
+            <Input
+              id="password_confirmation"
+              type="password"
+              value={passwordConfirmation}
+              onChange={(e) => setPasswordConfirmation(e.target.value)}
+              autoComplete="new-password"
+              placeholder="Confirm Password"
+            />
+          </div>
+          <div className="grid gap-2">
+            <Label htmlFor="image">Profile Image (optional)</Label>
+            <div className="flex items-end gap-4">
+              {imagePreview && (
+                <div className="relative w-16 h-16 rounded-sm overflow-hidden">
+                  <img src={imagePreview} alt="Profile preview" className="object-cover w-full h-full" />
+                </div>
+              )}
+              <div className="flex items-center gap-2 w-full">
+                <Input id="image" type="file" accept="image/*" onChange={handleImageChange} className="w-full" />
+                {imagePreview && <X className="cursor-pointer" onClick={() => { setImage(null); setImagePreview(null); }} />}
+              </div>
+            </div>
+          </div>
+          <Button
+            type="submit"
+            className="w-full"
+            disabled={loading}
+            onClick={async () => {
+              await signUp.email({
+                email,
+                password,
+                name: `${firstName} ${lastName}`,
+                image: image ? await convertImageToBase64(image) : '',
+                callbackURL: '/dashboard',
+                fetchOptions: {
+                  onResponse: () => {
+                    setLoading(false)
+                  },
+                  onRequest: () => {
+                    setLoading(true)
+                  },
+                  onSuccess: async () => {
+                    // handle success
+                  },
+                },
+              })
+            }}
+          >
+            {loading ? <Loader2 size={16} className="animate-spin" /> : 'Create an account'}
+          </Button>
+        </div>
+      </CardContent>
+      <CardFooter>
+        <div className="flex justify-center w-full border-t py-4">
+          <p className="text-center text-xs text-neutral-500">
+            Secured by <span className="text-orange-400">better-auth.</span>
+          </p>
+        </div>
+      </CardFooter>
+    </Card>
+  )
+}
+
+async function convertImageToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onloadend = () => resolve(reader.result as string)
+    reader.onerror = reject
+    reader.readAsDataURL(file)
+  })
+}

--- a/apps/web/src/components/ui/card.tsx
+++ b/apps/web/src/components/ui/card.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export type CardProps = React.HTMLAttributes<HTMLDivElement>
+
+const Card = React.forwardRef<HTMLDivElement, CardProps>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)} {...props} />
+))
+Card.displayName = 'Card'
+
+const CardHeader = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('flex flex-col space-y-1.5 p-6', className)} {...props} />
+))
+CardHeader.displayName = 'CardHeader'
+
+const CardTitle = React.forwardRef<HTMLHeadingElement, React.HTMLAttributes<HTMLHeadingElement>>(({ className, ...props }, ref) => (
+  <h3 ref={ref} className={cn('text-lg font-semibold leading-none tracking-tight', className)} {...props} />
+))
+CardTitle.displayName = 'CardTitle'
+
+const CardDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn('text-sm text-muted-foreground', className)} {...props} />
+))
+CardDescription.displayName = 'CardDescription'
+
+const CardContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('p-6 pt-0', className)} {...props} />
+))
+CardContent.displayName = 'CardContent'
+
+const CardFooter = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn('flex items-center p-6 pt-0', className)} {...props} />
+))
+CardFooter.displayName = 'CardFooter'
+
+export { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter }

--- a/apps/web/src/components/ui/checkbox.tsx
+++ b/apps/web/src/components/ui/checkbox.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export type CheckboxProps = React.InputHTMLAttributes<HTMLInputElement>
+
+const Checkbox = React.forwardRef<HTMLInputElement, CheckboxProps>(({ className, ...props }, ref) => (
+  <input
+    type="checkbox"
+    ref={ref}
+    className={cn(
+      'h-4 w-4 rounded border border-input text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+      className
+    )}
+    {...props}
+  />
+))
+Checkbox.displayName = 'Checkbox'
+
+export { Checkbox }

--- a/apps/web/src/components/ui/input.tsx
+++ b/apps/web/src/components/ui/input.tsx
@@ -1,0 +1,23 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export type InputProps = React.InputHTMLAttributes<HTMLInputElement>
+
+const Input = React.forwardRef<HTMLInputElement, InputProps>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+          className
+        )}
+        ref={ref}
+        {...props}
+      />
+    )
+  }
+)
+Input.displayName = 'Input'
+
+export { Input }

--- a/apps/web/src/components/ui/label.tsx
+++ b/apps/web/src/components/ui/label.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react'
+import { cn } from '@/lib/utils'
+
+export type LabelProps = React.LabelHTMLAttributes<HTMLLabelElement>
+
+const Label = React.forwardRef<HTMLLabelElement, LabelProps>(
+  ({ className, ...props }, ref) => (
+    <label
+      ref={ref}
+      className={cn(
+        'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70',
+        className
+      )}
+      {...props}
+    />
+  )
+)
+Label.displayName = 'Label'
+
+export { Label }

--- a/apps/web/src/lib/auth-client.ts
+++ b/apps/web/src/lib/auth-client.ts
@@ -1,0 +1,9 @@
+import { createAuthClient } from 'better-auth/react'
+import { passkeyClient } from 'better-auth/client/plugins'
+
+export const authClient = createAuthClient({
+  baseURL: import.meta.env.VITE_APP_URL,
+  plugins: [passkeyClient()],
+})
+
+export const { signIn, signOut, signUp, useSession } = authClient

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,0 +1,44 @@
+import { betterAuth } from 'better-auth'
+import { passkey } from 'better-auth/plugins'
+
+export const auth = betterAuth({
+  emailAndPassword: {
+    enabled: true,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    async sendResetPassword(_data, _request) {
+      // TODO: implement email sending logic
+    },
+  },
+  socialProviders: {
+    google: {
+      clientId: process.env.GOOGLE_CLIENT_ID!,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+    },
+    github: {
+      clientId: process.env.GITHUB_CLIENT_ID!,
+      clientSecret: process.env.GITHUB_CLIENT_SECRET!,
+    },
+    apple: {
+      clientId: process.env.APPLE_CLIENT_ID!,
+      clientSecret: process.env.APPLE_CLIENT_SECRET!,
+    },
+    twitter: {
+      clientId: process.env.TWITTER_CLIENT_ID!,
+      clientSecret: process.env.TWITTER_CLIENT_SECRET!,
+    },
+    microsoft: {
+      clientId: process.env.MICROSOFT_CLIENT_ID!,
+      clientSecret: process.env.MICROSOFT_CLIENT_SECRET!,
+    },
+    linkedin: {
+      clientId: process.env.LINKEDIN_CLIENT_ID!,
+      clientSecret: process.env.LINKEDIN_CLIENT_SECRET!,
+    },
+    facebook: {
+      clientId: process.env.FACEBOOK_CLIENT_ID!,
+      clientSecret: process.env.FACEBOOK_CLIENT_SECRET!,
+    },
+  },
+  plugins: [passkey()],
+  // if no database is provided, the user data will be stored in memory.
+})


### PR DESCRIPTION
## Summary
- integrate `better-auth` with base configuration and client helpers
- add reusable UI primitives (Card, Input, Label, Checkbox)
- create SignIn and SignUp components using the new auth client
- clean up unused imports in `App.tsx`
- declare `better-auth` dependency for web app

## Testing
- `pnpm --filter @revhc/web lint`

------
https://chatgpt.com/codex/tasks/task_e_6847b379860083299dca4d7eaa13792f