### PR TITLE
Implement reset password email support

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,9 @@ side state management and [TanStack DB](https://tanstack.com/db) for local
 storage. An initial schema defines a `users` table to keep track of patients and
 healthcare providers and their roles. Utility helpers in `src/store` provide a
 simple API to update and read the current user.
+
+## Email configuration
+
+Password reset emails are sent via a POST request to the URL provided in the
+`EMAIL_API_URL` environment variable. Configure this variable to point to your
+email service endpoint.

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -4,9 +4,26 @@ import { passkey } from 'better-auth/plugins'
 export const auth = betterAuth({
   emailAndPassword: {
     enabled: true,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    async sendResetPassword(_data, _request) {
-      // TODO: implement email sending logic
+    async sendResetPassword(data) {
+      const email = (data.user as any).email
+      if (!email || !process.env.EMAIL_API_URL) {
+        console.warn('Email service not configured or user email missing.')
+        return
+      }
+
+      try {
+        await fetch(process.env.EMAIL_API_URL, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            to: email,
+            subject: 'Reset your password',
+            html: `<p>Click <a href="${data.url}">here</a> to reset your password.</p>`,
+          }),
+        })
+      } catch (err) {
+        console.error('Failed to send reset password email', err)
+      }
     },
   },
   socialProviders: {


### PR DESCRIPTION
## Summary
- send reset password email using a configurable API endpoint
- document the `EMAIL_API_URL` variable

## Testing
- `pnpm lint` *(fails: Could not find turbo.json)*
- `pnpm build` *(fails: Could not find turbo.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847d84406ac8329afbde5fb0f60d02b