### PR TITLE
Center chat content area

### DIFF
--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -71,7 +71,7 @@ export default function Chat() {
   };
 
   return (
-    <div className="flex flex-col h-screen">
+    <div className="flex flex-col flex-1 w-full max-w-3xl mx-auto">
       <div className="flex-1 overflow-auto p-4 space-y-2">
         {messages.map((msg) => (
           <div


### PR DESCRIPTION
## Summary
- center the chat UI within a max width so it's easier to read on wide monitors

## Testing
- `pnpm lint` *(fails: Could not find turbo.json)*

------
https://chatgpt.com/codex/tasks/task_e_6847f97cfa5483299367f291c890b2a5