### PR TITLE
Implement multi-chat sidebar

### DIFF
--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -14,11 +14,29 @@ interface Message {
   content: string;
 }
 
+interface Chat {
+  id: number;
+  title: string;
+  messages: Message[];
+}
+
 export default function Chat() {
-  const [messages, setMessages] = useState<Message[]>([]);
+  const initialId = Date.now();
+  const [chats, setChats] = useState<Chat[]>([
+    { id: initialId, title: "New Chat", messages: [] },
+  ]);
+  const [currentChatId, setCurrentChatId] = useState<number>(initialId);
   const [input, setInput] = useState("");
   const [listening, setListening] = useState(false);
   const recognitionRef = useRef<SpeechRecognition | null>(null);
+
+  const currentChat = chats.find((c) => c.id === currentChatId)!;
+
+  const startNewChat = () => {
+    const id = Date.now();
+    setChats((chs) => [...chs, { id, title: "New Chat", messages: [] }]);
+    setCurrentChatId(id);
+  };
 
   useEffect(() => {
     const SpeechRecognitionClass =
@@ -51,6 +69,12 @@ export default function Chat() {
     }
   };
 
+  const truncateTitle = (text: string, words = 4) => {
+    const parts = text.trim().split(/\s+/);
+    const snippet = parts.slice(0, words).join(" ");
+    return parts.length > words ? `${snippet}...` : snippet || "New Chat";
+  };
+
   const sendMessage = () => {
     if (!input.trim()) return;
     const userMessage: Message = {
@@ -58,51 +82,91 @@ export default function Chat() {
       role: "user",
       content: input,
     };
-    setMessages((m) => [...m, userMessage]);
+
+    setChats((chs) =>
+      chs.map((c) => {
+        if (c.id !== currentChatId) return c;
+        const updated = {
+          ...c,
+          messages: [...c.messages, userMessage],
+          title:
+            c.title === "New Chat" ? truncateTitle(input) : c.title,
+        };
+        return updated;
+      })
+    );
+
     const reply: Message = {
       id: Date.now() + 1,
       role: "assistant",
       content: `You said: ${input}`,
     };
     setTimeout(() => {
-      setMessages((m) => [...m, reply]);
+      setChats((chs) =>
+        chs.map((c) =>
+          c.id === currentChatId
+            ? { ...c, messages: [...c.messages, reply] }
+            : c
+        )
+      );
     }, 300);
     setInput("");
   };
 
   return (
-    <div className="flex flex-col h-screen">
-      <div className="flex-1 overflow-auto p-4 space-y-2">
-        {messages.map((msg) => (
-          <div
-            key={msg.id}
-            className={
-              msg.role === "user" ? "flex justify-end" : "flex justify-start"
-            }
-          >
-            <Card className="max-w-md">
-              <CardContent className="p-2">
-                <p>{msg.content}</p>
-              </CardContent>
-            </Card>
-          </div>
-        ))}
-      </div>
-      <div className="p-4 flex gap-2 border-t">
-        <Input
-          placeholder="Type a message..."
-          value={input}
-          onChange={(e) => setInput(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              sendMessage();
-            }
-          }}
-        />
-        <Button variant="ghost" size="icon" onClick={toggleListening}>
-          {listening ? <MicOff size={20} /> : <Mic size={20} />}
+    <div className="flex h-screen">
+      <div className="w-48 border-r p-2 flex flex-col">
+        <Button size="sm" className="mb-2" onClick={startNewChat}>
+          + New Chat
         </Button>
-        <Button onClick={sendMessage}>Send</Button>
+        <div className="flex-1 overflow-auto space-y-1">
+          {chats.map((chat) => (
+            <Button
+              key={chat.id}
+              variant={
+                chat.id === currentChatId ? "secondary" : "ghost"
+              }
+              className="w-full justify-start"
+              onClick={() => setCurrentChatId(chat.id)}
+            >
+              {chat.title}
+            </Button>
+          ))}
+        </div>
+      </div>
+      <div className="flex-1 flex flex-col">
+        <div className="flex-1 overflow-auto p-4 space-y-2">
+          {currentChat.messages.map((msg) => (
+            <div
+              key={msg.id}
+              className={
+                msg.role === "user" ? "flex justify-end" : "flex justify-start"
+              }
+            >
+              <Card className="max-w-md">
+                <CardContent className="p-2">
+                  <p>{msg.content}</p>
+                </CardContent>
+              </Card>
+            </div>
+          ))}
+        </div>
+        <div className="p-4 flex gap-2 border-t">
+          <Input
+            placeholder="Type a message..."
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                sendMessage();
+              }
+            }}
+          />
+          <Button variant="ghost" size="icon" onClick={toggleListening}>
+            {listening ? <MicOff size={20} /> : <Mic size={20} />}
+          </Button>
+          <Button onClick={sendMessage}>Send</Button>
+        </div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- extend Chat component with multi-session support
- add sidebar to start and switch chats
- show truncated chat titles

## Testing
- `pnpm --filter @revhc/web lint`
- `pnpm --filter @revhc/web build` *(fails: Cannot find name 'SpeechRecognition', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6847fa2dd4788329ab8d74a35ec0060e