### PR TITLE
Fix chat title wrapping

### DIFF
--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -126,7 +126,7 @@ export default function Chat() {
               variant={
                 chat.id === currentChatId ? "secondary" : "ghost"
               }
-              className="w-full justify-start"
+              className="w-full justify-start truncate"
               onClick={() => setCurrentChatId(chat.id)}
             >
               {chat.title}


### PR DESCRIPTION
## Summary
- prevent sidebar chat titles from wrapping by using Tailwind's `truncate` class

## Testing
- `pnpm lint` *(fails: Could not find turbo.json or turbo.jsonc)*

------
https://chatgpt.com/codex/tasks/task_e_6847fc9d779c83299cea5ddee9345bf2