### PR TITLE
Add chat width toggle button

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,8 @@
 import SignIn from "@/components/sign-in";
 import Chat from "@/components/chat";
 import ThemeToggle from "@/components/theme-toggle";
+import { Maximize2, Minimize2 } from "lucide-react";
+import { useState } from "react";
 import {
   useCurrentUser,
   setCurrentUser,
@@ -10,6 +12,7 @@ import { Button } from "@/components/ui/button";
 
 function App() {
   const currentUser = useCurrentUser();
+  const [expanded, setExpanded] = useState(false);
 
   if (!currentUser) {
     return (
@@ -35,12 +38,24 @@ function App() {
         <p className="text-sm">Logged in as {currentUser.name}</p>
         <div className="flex items-center gap-2">
           <ThemeToggle />
+          <Button
+            variant="ghost"
+            size="icon"
+            className="hidden md:inline-flex"
+            onClick={() => setExpanded((e) => !e)}
+          >
+            {expanded ? (
+              <Minimize2 className="h-4 w-4" />
+            ) : (
+              <Maximize2 className="h-4 w-4" />
+            )}
+          </Button>
           <Button size="sm" onClick={clearCurrentUser}>
             Log out
           </Button>
         </div>
       </div>
-      <Chat />
+      <Chat expanded={expanded} />
     </div>
   );
 }

--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
@@ -20,7 +21,7 @@ interface Chat {
   messages: Message[];
 }
 
-export default function Chat() {
+export default function Chat({ expanded }: { expanded: boolean }) {
   const initialId = Date.now();
   const [chats, setChats] = useState<Chat[]>([
     { id: initialId, title: "New Chat", messages: [] },
@@ -114,7 +115,12 @@ export default function Chat() {
   };
 
   return (
-    <div className="flex h-screen">
+    <div
+      className={cn(
+        "flex h-screen md:h-full",
+        expanded ? "w-full" : "md:max-w-4xl md:mx-auto"
+      )}
+    >
       <div className="w-48 border-r p-2 flex flex-col">
         <Button size="sm" className="mb-2" onClick={startNewChat}>
           + New Chat


### PR DESCRIPTION
## Summary
- add toggle button in header to expand or shrink chat width
- make `Chat` component responsive with optional max width

## Testing
- `pnpm --filter web lint`
- `pnpm --filter web build` *(fails: Module 'better-auth/plugins' has no exported member 'passkey')*

------
https://chatgpt.com/codex/tasks/task_e_6847fce7f85883298d5533294ad30282