### PR TITLE
Fix chat title ellipsis

### DIFF
--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -126,10 +126,10 @@ export default function Chat() {
               variant={
                 chat.id === currentChatId ? "secondary" : "ghost"
               }
-              className="w-full justify-start truncate"
+              className="w-full justify-start"
               onClick={() => setCurrentChatId(chat.id)}
             >
-              {chat.title}
+              <span className="truncate">{chat.title}</span>
             </Button>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- ensure the ellipsis appears on truncated chat titles

## Testing
- `pnpm lint`
- `pnpm --filter @revhc/web lint`

------
https://chatgpt.com/codex/tasks/task_e_6847fded3b8c832984d71798e33900b3