### PR TITLE
Fix chat layout spacing

### DIFF
--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -117,11 +117,11 @@ export default function Chat({ expanded }: { expanded: boolean }) {
   return (
     <div
       className={cn(
-        "flex h-screen md:h-full",
-        expanded ? "w-full" : "md:max-w-4xl md:mx-auto"
+        "flex h-screen md:h-full pl-48",
+        expanded ? "w-full" : "md:max-w-6xl md:mx-auto"
       )}
     >
-      <div className="w-48 border-r p-2 flex flex-col">
+      <div className="fixed inset-y-0 left-0 w-48 border-r p-2 flex flex-col bg-background">
         <Button size="sm" className="mb-2" onClick={startNewChat}>
           + New Chat
         </Button>


### PR DESCRIPTION
## Summary
- keep sidebar fixed
- allow more room for chat when collapsed

## Testing
- `pnpm lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684801b9428c832999df82ccb639730e