### PR TITLE
Persist theme toggle in session storage

### DIFF
--- a/apps/web/src/components/theme-toggle.tsx
+++ b/apps/web/src/components/theme-toggle.tsx
@@ -11,7 +11,7 @@ export default function ThemeToggle() {
   })
 
   useEffect(() => {
-    const stored = localStorage.getItem('theme') as 'light' | 'dark' | null
+    const stored = sessionStorage.getItem('theme') as 'light' | 'dark' | null
     if (stored) {
       setTheme(stored)
     }
@@ -23,7 +23,7 @@ export default function ThemeToggle() {
     } else {
       document.documentElement.classList.remove('dark')
     }
-    localStorage.setItem('theme', theme)
+    sessionStorage.setItem('theme', theme)
   }, [theme])
 
   return (


### PR DESCRIPTION
## Summary
- persist theme selection using `sessionStorage`

## Testing
- `pnpm --filter web lint`


------
https://chatgpt.com/codex/tasks/task_e_684801faba548329a017ec22bfc55642