### PR TITLE
Fix sidebar layout

### DIFF
--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -118,9 +118,8 @@ export default function Chat({ expanded }: { expanded: boolean }) {
   return (
     <div
       className={cn(
-        "flex h-screen md:h-full",
-        sidebarRight ? "flex-row-reverse" : "flex-row",
-        expanded ? "w-full" : "md:max-w-4xl md:mx-auto"
+        "flex h-screen md:h-full w-full",
+        sidebarRight ? "flex-row-reverse" : "flex-row"
       )}
     >
       <div
@@ -156,7 +155,12 @@ export default function Chat({ expanded }: { expanded: boolean }) {
           ))}
         </div>
       </div>
-      <div className="flex-1 flex flex-col">
+      <div
+        className={cn(
+          "flex-1 flex flex-col",
+          expanded ? "" : "md:max-w-4xl md:mx-auto w-full"
+        )}
+      >
         <div className="flex-1 overflow-auto p-4 space-y-2">
           {currentChat.messages.map((msg) => (
             <div


### PR DESCRIPTION
## Summary
- keep the Chat wrapper full width so the sidebar sits against the viewport
- center the chat area only when not expanded

## Testing
- `pnpm lint`
- `pnpm --filter web lint`
- `pnpm --filter web build` *(fails: Module '"better-auth/plugins"' has no exported member 'passkey')*

------
https://chatgpt.com/codex/tasks/task_e_684808f95c7c8329982372dc02157101