### PR TITLE
Use upload-artifact v4 for page deploys

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -28,9 +28,12 @@ jobs:
           cache: 'pnpm'
       - run: pnpm install --no-frozen-lockfile
       - run: pnpm --filter @revhc/web build
-      - uses: actions/upload-pages-artifact@v2
+      - uses: actions/upload-artifact@v4
         with:
+          name: github-pages
           path: apps/web/dist
+          if-no-files-found: error
+          retention-days: 1
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- update the Pages workflow to upload with `actions/upload-artifact@v4`

## Testing
- `pnpm lint` *(fails: Could not find turbo.json)*
- `pnpm build` *(fails: Could not find turbo.json)*

------
https://chatgpt.com/codex/tasks/task_e_6848583f7a4083299f8aa40bd18cd6a3