### PR TITLE
Add mobile sidebar overlay

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,7 @@
 import SignIn from "@/components/sign-in";
 import Chat from "@/components/chat";
 import ThemeToggle from "@/components/theme-toggle";
-import { Maximize2, Minimize2 } from "lucide-react";
+import { Maximize2, Minimize2, Menu } from "lucide-react";
 import { useState } from "react";
 import {
   useCurrentUser,
@@ -13,6 +13,7 @@ import { Button } from "@/components/ui/button";
 function App() {
   const currentUser = useCurrentUser();
   const [expanded, setExpanded] = useState(false);
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
   if (!currentUser) {
     return (
@@ -35,7 +36,17 @@ function App() {
   return (
     <div className="h-screen flex flex-col">
       <div className="p-2 border-b flex justify-between items-center">
-        <p className="text-sm">Logged in as {currentUser.name}</p>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="md:hidden"
+            onClick={() => setMobileSidebarOpen(true)}
+          >
+            <Menu className="h-5 w-5" />
+          </Button>
+          <p className="text-sm">Logged in as {currentUser.name}</p>
+        </div>
         <div className="flex items-center gap-2">
           <ThemeToggle />
           <Button
@@ -55,7 +66,11 @@ function App() {
           </Button>
         </div>
       </div>
-      <Chat expanded={expanded} />
+      <Chat
+        expanded={expanded}
+        mobileSidebarOpen={mobileSidebarOpen}
+        setMobileSidebarOpen={setMobileSidebarOpen}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -34,7 +34,15 @@ type ChatItem = Chat | ChatFolder;
 const isFolder = (item: ChatItem): item is ChatFolder =>
   (item as ChatFolder).chats !== undefined;
 
-export default function Chat({ expanded }: { expanded: boolean }) {
+export default function Chat({
+  expanded,
+  mobileSidebarOpen,
+  setMobileSidebarOpen,
+}: {
+  expanded: boolean;
+  mobileSidebarOpen: boolean;
+  setMobileSidebarOpen: React.Dispatch<React.SetStateAction<boolean>>;
+}) {
   const initialId = Date.now();
   const [chats, setChats] = useState<ChatItem[]>([
     { id: initialId, title: "New Chat", messages: [] },
@@ -289,19 +297,13 @@ export default function Chat({ expanded }: { expanded: boolean }) {
     setInput("");
   };
 
-  return (
+  const sidebar = (
     <div
       className={cn(
-        "flex h-screen md:h-full w-full",
-        sidebarRight ? "flex-row-reverse" : "flex-row"
+        "w-48 p-2 flex flex-col bg-background h-full",
+        sidebarRight ? "border-l" : "border-r"
       )}
     >
-      <div
-        className={cn(
-          "w-48 p-2 flex flex-col",
-          sidebarRight ? "border-l" : "border-r"
-        )}
-      >
         <div className="flex items-center justify-between mb-2 pb-2 border-b">
           <Button size="sm" onClick={startNewChat}>
             + New Chat
@@ -392,6 +394,32 @@ export default function Chat({ expanded }: { expanded: boolean }) {
           )}
         </div>
       </div>
+  );
+
+  return (
+    <div
+      className={cn(
+        "flex h-screen md:h-full w-full relative",
+        sidebarRight ? "flex-row-reverse" : "flex-row"
+      )}
+    >
+      <div className="hidden md:flex">{sidebar}</div>
+      {mobileSidebarOpen && (
+        <div className="md:hidden fixed inset-0 z-50">
+          <div
+            className="absolute inset-0 bg-black/50"
+            onClick={() => setMobileSidebarOpen(false)}
+          />
+          <div
+            className={cn(
+              "absolute top-0 bottom-0",
+              sidebarRight ? "right-0" : "left-0"
+            )}
+          >
+            {sidebar}
+          </div>
+        </div>
+      )}
       <div
         className={cn(
           "flex-1 flex flex-col",


### PR DESCRIPTION
## Summary
- add hamburger icon button to toggle sidebar on mobile
- overlay sidebar with greyed out page on small screens

## Testing
- `pnpm lint` *(fails: command exited with code 1)*

------
https://chatgpt.com/codex/tasks/task_e_68487cbb71d48329ae120aa84945207d