### PR TITLE
Fix mobile height

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -16,8 +16,8 @@ function App() {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
 
   if (!currentUser) {
-    return (
-      <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+      return (
+        <div className="flex flex-col items-center justify-center min-h-dvh gap-4">
         <div className="absolute top-4 right-4">
           <ThemeToggle />
         </div>
@@ -33,8 +33,8 @@ function App() {
     );
   }
 
-  return (
-    <div className="h-screen flex flex-col">
+    return (
+      <div className="h-dvh flex flex-col">
       <div className="p-2 border-b flex justify-between items-center">
         <div className="flex items-center gap-2">
           <Button

--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -399,7 +399,7 @@ export default function Chat({
   return (
     <div
       className={cn(
-        "flex h-screen md:h-full w-full relative",
+        "flex h-dvh md:h-full w-full relative",
         sidebarRight ? "flex-row-reverse" : "flex-row"
       )}
     >

--- a/apps/web/src/index.css
+++ b/apps/web/src/index.css
@@ -77,6 +77,6 @@
   html,
   body,
   #root {
-    @apply w-full h-full;
+    @apply w-full min-h-dvh;
   }
 }


### PR DESCRIPTION
## Summary
- ensure the app root stretches to the dynamic viewport height
- avoid 100vh usage on mobile by switching to new `dvh` units

## Testing
- `pnpm lint` *(fails: Unexpected any issues in unrelated files)*
- `pnpm --filter web build`

------
https://chatgpt.com/codex/tasks/task_e_6848fba36a4c8329a651a91096c6d559