### PR TITLE
Update dashboard flow

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,6 @@
 import SignIn from "@/components/sign-in";
 import Chat from "@/components/chat";
-import HomeDashboard from "@/components/home-dashboard";
+import HomeDashboard, { Concern } from "@/components/home-dashboard";
 import ThemeToggle from "@/components/theme-toggle";
 import { Maximize2, Minimize2, Menu } from "lucide-react";
 import { useState } from "react";
@@ -15,6 +15,7 @@ function App() {
   const currentUser = useCurrentUser();
   const [expanded, setExpanded] = useState(false);
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
+  const [selectedConcern, setSelectedConcern] = useState<Concern | null>(null);
 
   if (!currentUser) {
       return (
@@ -38,6 +39,11 @@ function App() {
       <div className="h-dvh flex flex-col">
       <div className="p-2 border-b flex justify-between items-center">
         <div className="flex items-center gap-2">
+          {selectedConcern && (
+            <Button variant="ghost" size="sm" onClick={() => setSelectedConcern(null)}>
+              Back
+            </Button>
+          )}
           <Button
             variant="ghost"
             size="icon"
@@ -67,12 +73,15 @@ function App() {
           </Button>
         </div>
       </div>
-      <HomeDashboard />
-      <Chat
-        expanded={expanded}
-        mobileSidebarOpen={mobileSidebarOpen}
-        setMobileSidebarOpen={setMobileSidebarOpen}
-      />
+      {selectedConcern ? (
+        <Chat
+          expanded={expanded}
+          mobileSidebarOpen={mobileSidebarOpen}
+          setMobileSidebarOpen={setMobileSidebarOpen}
+        />
+      ) : (
+        <HomeDashboard onSelectConcern={setSelectedConcern} />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/home-dashboard.tsx
+++ b/apps/web/src/components/home-dashboard.tsx
@@ -15,7 +15,11 @@ const initialConcerns: Concern[] = [
   { id: 1, title: 'Stomach Pain', diagnosis: 'Indigestion', date: '2024-05-28' },
 ]
 
-export default function HomeDashboard() {
+export default function HomeDashboard({
+  onSelectConcern,
+}: {
+  onSelectConcern: (c: Concern) => void
+}) {
   const [layout, setLayout] = useState<'latest' | 'date'>('latest')
   const [reverse, setReverse] = useState(false)
 
@@ -42,7 +46,7 @@ export default function HomeDashboard() {
       </div>
       <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
         {sorted.map((c) => (
-          <Card key={c.id}>
+          <Card key={c.id} onClick={() => onSelectConcern(c)} className="cursor-pointer">
             <CardHeader>
               <CardTitle>{c.title}</CardTitle>
             </CardHeader>


### PR DESCRIPTION
## Summary
- show home dashboard first after login
- open chat after selecting a concern
- allow going back to the concern list

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684e49c65e448329b7415b8abfbec8a8