### PR TITLE
Add icons for home dashboard controls

### DIFF
--- a/apps/web/src/components/home-dashboard.tsx
+++ b/apps/web/src/components/home-dashboard.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { Card, CardHeader, CardTitle, CardContent } from '@/components/ui/card'
 import { Button } from '@/components/ui/button'
+import { CalendarDays, Clock, ArrowUpDown } from 'lucide-react'
 
 export interface Concern {
   id: number
@@ -36,12 +37,24 @@ export default function HomeDashboard({
 
   return (
     <div className="p-4 space-y-4">
-      <div className="flex gap-2">
-        <Button variant="outline" onClick={() => setLayout(layout === 'latest' ? 'date' : 'latest')}>
-          Layout: {layout === 'latest' ? 'Latest' : 'By Date'}
+      <div className="flex gap-2 justify-end">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => setLayout(layout === 'latest' ? 'date' : 'latest')}
+        >
+          {layout === 'latest' ? (
+            <Clock className="h-4 w-4" />
+          ) : (
+            <CalendarDays className="h-4 w-4" />
+          )}
         </Button>
-        <Button variant="outline" onClick={() => setReverse(r => !r)}>
-          Reverse Order
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={() => setReverse((r) => !r)}
+        >
+          <ArrowUpDown className="h-4 w-4" />
         </Button>
       </div>
       <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">


### PR DESCRIPTION
## Summary
- convert layout and order buttons to icon buttons
- align control buttons to the top right of the home dashboard

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684e819fc9388329b57877309878f5f4