### PR TITLE
Fix Concern import for verbatimModuleSyntax

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,6 @@
 import SignIn from "@/components/sign-in";
 import Chat from "@/components/chat";
-import HomeDashboard, { Concern } from "@/components/home-dashboard";
+import HomeDashboard, { type Concern } from "@/components/home-dashboard";
 import ThemeToggle from "@/components/theme-toggle";
 import { Maximize2, Minimize2, Menu } from "lucide-react";
 import { useState } from "react";


### PR DESCRIPTION
## Summary
- fix home dashboard import in `App.tsx` due to `verbatimModuleSyntax`

## Testing
- `pnpm --filter @revhc/web build`


------
https://chatgpt.com/codex/tasks/task_e_684f700bd1c483298dcfdd3f35d891c3