### PR TITLE
Fix dark sidebar contrast

### DIFF
--- a/apps/web/src/components/chat.tsx
+++ b/apps/web/src/components/chat.tsx
@@ -355,7 +355,7 @@ export default function Chat({
   const sidebar = (
     <div
       className={cn(
-        "w-48 p-2 flex flex-col bg-background h-full",
+        "w-48 p-2 flex flex-col bg-background dark:bg-neutral-900 h-full",
         sidebarRight ? "border-l" : "border-r"
       )}
     >


### PR DESCRIPTION
## Summary
- adjust dark theme sidebar background so it stands out from the overlay

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_684f84f00e608329ab516dcae6c5528a