### PR TITLE
Fix sidebar open state when selecting concern

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -17,6 +17,11 @@ function App() {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [selectedConcern, setSelectedConcern] = useState<Concern | null>(null);
 
+  const handleSelectConcern = (c: Concern) => {
+    setMobileSidebarOpen(false);
+    setSelectedConcern(c);
+  };
+
   if (!currentUser) {
       return (
         <div className="flex flex-col items-center justify-center min-h-dvh gap-4">
@@ -80,7 +85,7 @@ function App() {
           setMobileSidebarOpen={setMobileSidebarOpen}
         />
       ) : (
-        <HomeDashboard onSelectConcern={setSelectedConcern} />
+        <HomeDashboard onSelectConcern={handleSelectConcern} />
       )}
     </div>
   );


### PR DESCRIPTION
## Summary
- close the chat sidebar when selecting a new concern

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685065e97f84832991f8534c78847883