### PR TITLE
Add avatar for current user

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import SignIn from "@/components/sign-in";
 import Chat from "@/components/chat";
 import HomeDashboard, { type Concern } from "@/components/home-dashboard";
 import ThemeToggle from "@/components/theme-toggle";
+import Avatar from "@/components/avatar";
 import { Maximize2, Minimize2, Menu } from "lucide-react";
 import { useState } from "react";
 import {
@@ -57,7 +58,7 @@ function App() {
           >
             <Menu className="h-5 w-5" />
           </Button>
-          <p className="text-sm">Logged in as {currentUser.name}</p>
+          <Avatar name={currentUser.name} />
         </div>
         <div className="flex items-center gap-2">
           <ThemeToggle />

--- a/apps/web/src/components/avatar.tsx
+++ b/apps/web/src/components/avatar.tsx
@@ -1,0 +1,25 @@
+import { User } from 'lucide-react'
+import { cn } from '@/lib/utils'
+
+export default function Avatar({ name, className }: { name: string; className?: string }) {
+  const initials = name
+    .split(/\s+/)
+    .map((n) => n[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase()
+
+  return (
+    <div
+      className={cn(
+        'relative w-8 h-8 rounded-md bg-muted flex items-center justify-center overflow-hidden',
+        className,
+      )}
+    >
+      <User className="w-5 h-5 text-muted-foreground" />
+      <span className="absolute bottom-0 right-0 mb-0.5 mr-0.5 rounded bg-primary text-primary-foreground text-[10px] leading-none px-1">
+        {initials}
+      </span>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add Avatar component showing user initials
- use Avatar in app header instead of text

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_685067e018c88329855ae4ce5d1f36b7