### PR TITLE
Adjust avatar overlay styling

### DIFF
--- a/apps/web/src/components/avatar.tsx
+++ b/apps/web/src/components/avatar.tsx
@@ -17,7 +17,9 @@ export default function Avatar({ name, className }: { name: string; className?: 
       )}
     >
       <User className="w-5 h-5 text-muted-foreground" />
-      <span className="absolute bottom-0 right-0 mb-0.5 mr-0.5 rounded bg-primary text-primary-foreground text-[10px] leading-none px-1">
+      <span
+        className="absolute bottom-0 right-0 mb-0.5 mr-0.5 rounded bg-primary text-primary-foreground text-[8px] leading-none flex items-center justify-center w-4 h-4"
+      >
         {initials}
       </span>
     </div>


### PR DESCRIPTION
## Summary
- tweak the avatar overlay to use a square shape and smaller text

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_68506adff5e083298d9568037e1a2b4a