### PR TITLE
Hide burger menu outside chat

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -50,14 +50,16 @@ function App() {
               Back
             </Button>
           )}
-          <Button
-            variant="ghost"
-            size="icon"
-            className="md:hidden"
-            onClick={() => setMobileSidebarOpen(true)}
-          >
-            <Menu className="h-5 w-5" />
-          </Button>
+          {selectedConcern && (
+            <Button
+              variant="ghost"
+              size="icon"
+              className="md:hidden"
+              onClick={() => setMobileSidebarOpen(true)}
+            >
+              <Menu className="h-5 w-5" />
+            </Button>
+          )}
           <Avatar name={currentUser.name} />
         </div>
         <div className="flex items-center gap-2">


### PR DESCRIPTION
## Summary
- render hamburger icon only when chat is open

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_685079a235008329ba90460ac2f57951