### PR TITLE
Add shadcn sidebar block

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,7 +3,13 @@ import Chat from "@/components/chat";
 import HomeDashboard, { type Concern } from "@/components/home-dashboard";
 import ThemeToggle from "@/components/theme-toggle";
 import Avatar from "@/components/avatar";
-import Sidebar from "@/components/sidebar";
+import { AppSidebar } from "@/components/app-sidebar";
+import {
+  SidebarProvider,
+  SidebarInset,
+  SidebarTrigger,
+} from "@/components/ui/sidebar";
+import { Separator } from "@/components/ui/separator";
 import { Home, Maximize2, Minimize2, Menu } from "lucide-react";
 import { useState } from "react";
 import {
@@ -16,11 +22,9 @@ import { Button } from "@/components/ui/button";
 function App() {
   const currentUser = useCurrentUser();
   const [expanded, setExpanded] = useState(false);
-  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false);
   const [selectedConcern, setSelectedConcern] = useState<Concern | null>(null);
 
   const handleSelectConcern = (c: Concern) => {
-    setMobileSidebarOpen(false);
     setSelectedConcern(c);
   };
 
@@ -43,63 +47,56 @@ function App() {
   }
 
     return (
-      <div className="h-dvh flex">
-        <Sidebar
-          mobileOpen={mobileSidebarOpen}
-          setMobileOpen={setMobileSidebarOpen}
-          onHome={() => setSelectedConcern(null)}
-        />
-        <div className="flex-1 flex flex-col">
-      <div className="p-2 border-b flex justify-between items-center">
-        <div className="flex items-center gap-2">
-          <Button
-            variant="ghost"
-            size="icon"
-            className="md:hidden"
-            onClick={() => setMobileSidebarOpen(true)}
-          >
-            <Menu className="h-5 w-5" />
-          </Button>
-          <Avatar name={currentUser.name} />
-          {selectedConcern && (
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setSelectedConcern(null)}
-            >
-              <Home className="h-4 w-4" />
-            </Button>
-          )}
-        </div>
-        <div className="flex items-center gap-2">
-          <ThemeToggle />
-          {selectedConcern && (
-            <Button
-              variant="ghost"
-              size="icon"
-              className="hidden md:inline-flex"
-              onClick={() => setExpanded((e) => !e)}
-            >
-              {expanded ? (
-                <Minimize2 className="h-4 w-4" />
-              ) : (
-                <Maximize2 className="h-4 w-4" />
+      <SidebarProvider>
+        <AppSidebar />
+        <SidebarInset>
+          <div className="p-2 border-b flex justify-between items-center">
+            <div className="flex items-center gap-2">
+              <SidebarTrigger className="md:hidden -ml-1">
+                <Menu className="h-4 w-4" />
+              </SidebarTrigger>
+              <Separator orientation="vertical" className="mr-2 h-4" />
+              <Avatar name={currentUser.name} />
+              {selectedConcern && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() => setSelectedConcern(null)}
+                >
+                  <Home className="h-4 w-4" />
+                </Button>
               )}
-            </Button>
+            </div>
+            <div className="flex items-center gap-2">
+              <ThemeToggle />
+              {selectedConcern && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="hidden md:inline-flex"
+                  onClick={() => setExpanded((e) => !e)}
+                >
+                  {expanded ? (
+                    <Minimize2 className="h-4 w-4" />
+                  ) : (
+                    <Maximize2 className="h-4 w-4" />
+                  )}
+                </Button>
+              )}
+              <Button size="sm" onClick={clearCurrentUser}>
+                Log out
+              </Button>
+            </div>
+          </div>
+          {selectedConcern ? (
+            <Chat expanded={expanded} />
+          ) : (
+            <HomeDashboard onSelectConcern={handleSelectConcern} />
           )}
-          <Button size="sm" onClick={clearCurrentUser}>
-            Log out
-          </Button>
-        </div>
-      </div>
-      {selectedConcern ? (
-        <Chat expanded={expanded} />
-      ) : (
-        <HomeDashboard onSelectConcern={handleSelectConcern} />
-      )}
-    </div>
-    </div>
-  );
+        </SidebarInset>
+      </SidebarProvider>
+    );
 }
 
 export default App;
+

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import {
+  Waves,
+  BookOpen,
+  Bot,
+  Command,
+  Frame,
+  GalleryVerticalEnd,
+  Map,
+  PieChart,
+  Settings2,
+  TerminalSquare,
+} from "lucide-react"
+
+import { NavMain } from "@/components/nav-main"
+import { NavProjects } from "@/components/nav-projects"
+import { NavUser } from "@/components/nav-user"
+import { TeamSwitcher } from "@/components/team-switcher"
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarRail,
+} from "@/components/ui/sidebar"
+
+// Sample data
+const data = {
+  user: {
+    name: "shadcn",
+    email: "m@example.com",
+    avatar: "/avatars/shadcn.jpg",
+  },
+  teams: [
+    {
+      name: "Acme Inc",
+      logo: GalleryVerticalEnd,
+      plan: "Enterprise",
+    },
+    {
+      name: "Acme Corp.",
+      logo: Waves,
+      plan: "Startup",
+    },
+    {
+      name: "Evil Corp.",
+      logo: Command,
+      plan: "Free",
+    },
+  ],
+  navMain: [
+    {
+      title: "Playground",
+      url: "#",
+      icon: TerminalSquare,
+      isActive: true,
+      items: [
+        { title: "History", url: "#" },
+        { title: "Starred", url: "#" },
+        { title: "Settings", url: "#" },
+      ],
+    },
+    {
+      title: "Models",
+      url: "#",
+      icon: Bot,
+      items: [
+        { title: "Genesis", url: "#" },
+        { title: "Explorer", url: "#" },
+        { title: "Quantum", url: "#" },
+      ],
+    },
+    {
+      title: "Documentation",
+      url: "#",
+      icon: BookOpen,
+      items: [
+        { title: "Introduction", url: "#" },
+        { title: "Get Started", url: "#" },
+        { title: "Tutorials", url: "#" },
+        { title: "Changelog", url: "#" },
+      ],
+    },
+    {
+      title: "Settings",
+      url: "#",
+      icon: Settings2,
+      items: [
+        { title: "General", url: "#" },
+        { title: "Team", url: "#" },
+        { title: "Billing", url: "#" },
+        { title: "Limits", url: "#" },
+      ],
+    },
+  ],
+  projects: [
+    { name: "Design Engineering", url: "#", icon: Frame },
+    { name: "Sales & Marketing", url: "#", icon: PieChart },
+    { name: "Travel", url: "#", icon: Map },
+  ],
+}
+
+export function AppSidebar(props: React.ComponentProps<typeof Sidebar>) {
+  return (
+    <Sidebar collapsible="icon" {...props}>
+      <SidebarHeader>
+        <TeamSwitcher teams={data.teams} />
+      </SidebarHeader>
+      <SidebarContent>
+        <NavMain items={data.navMain} />
+        <NavProjects projects={data.projects} />
+      </SidebarContent>
+      <SidebarFooter>
+        <NavUser user={data.user} />
+      </SidebarFooter>
+      <SidebarRail />
+    </Sidebar>
+  )
+}
+

--- a/apps/web/src/components/nav-main.tsx
+++ b/apps/web/src/components/nav-main.tsx
@@ -1,0 +1,73 @@
+"use client"
+
+import { ChevronRight, type LucideIcon } from "lucide-react"
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+} from "@/components/ui/sidebar"
+
+export function NavMain({
+  items,
+}: {
+  items: {
+    title: string
+    url: string
+    icon?: LucideIcon
+    isActive?: boolean
+    items?: {
+      title: string
+      url: string
+    }[]
+  }[]
+}) {
+  return (
+    <SidebarGroup>
+      <SidebarGroupLabel>Platform</SidebarGroupLabel>
+      <SidebarMenu>
+        {items.map((item) => (
+          <Collapsible
+            key={item.title}
+            defaultOpen={item.isActive}
+            className="group/collapsible"
+          >
+            <SidebarMenuItem>
+              <CollapsibleTrigger>
+                <SidebarMenuButton title={item.title}>
+                  {item.icon && <item.icon />}
+                  <span>{item.title}</span>
+                  <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+                </SidebarMenuButton>
+              </CollapsibleTrigger>
+              <CollapsibleContent>
+                <SidebarMenuSub>
+                  {item.items?.map((subItem) => (
+                    <SidebarMenuSubItem key={subItem.title}>
+                      <SidebarMenuSubButton>
+                        <a href={subItem.url}>
+                          <span>{subItem.title}</span>
+                        </a>
+                      </SidebarMenuSubButton>
+                    </SidebarMenuSubItem>
+                  ))}
+                </SidebarMenuSub>
+              </CollapsibleContent>
+            </SidebarMenuItem>
+          </Collapsible>
+        ))}
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}
+

--- a/apps/web/src/components/nav-projects.tsx
+++ b/apps/web/src/components/nav-projects.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import {
+  Folder,
+  Forward,
+  MoreHorizontal,
+  Trash2,
+  type LucideIcon,
+} from "lucide-react"
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  SidebarGroup,
+  SidebarGroupLabel,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from "@/components/ui/sidebar"
+
+export function NavProjects({
+  projects,
+}: {
+  projects: {
+    name: string
+    url: string
+    icon: LucideIcon
+  }[]
+}) {
+  useSidebar()
+
+  return (
+    <SidebarGroup className="group-data-[collapsible=icon]:hidden">
+      <SidebarGroupLabel>Projects</SidebarGroupLabel>
+      <SidebarMenu>
+        {projects.map((item) => (
+          <SidebarMenuItem key={item.name}>
+            <SidebarMenuButton>
+              <a href={item.url}>
+                <item.icon />
+                <span>{item.name}</span>
+              </a>
+            </SidebarMenuButton>
+            <DropdownMenu>
+              <DropdownMenuTrigger>
+                <SidebarMenuAction>
+                  <MoreHorizontal />
+                  <span className="sr-only">More</span>
+                </SidebarMenuAction>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent
+                className="w-48 rounded-lg"
+                style={{ position: "absolute" }}
+              >
+                <DropdownMenuItem>
+                  <Folder className="text-muted-foreground" />
+                  <span>View Project</span>
+                </DropdownMenuItem>
+                <DropdownMenuItem>
+                  <Forward className="text-muted-foreground" />
+                  <span>Share Project</span>
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem>
+                  <Trash2 className="text-muted-foreground" />
+                  <span>Delete Project</span>
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </SidebarMenuItem>
+        ))}
+        <SidebarMenuItem>
+          <SidebarMenuButton className="text-sidebar-foreground/70">
+            <MoreHorizontal className="text-sidebar-foreground/70" />
+            <span>More</span>
+          </SidebarMenuButton>
+        </SidebarMenuItem>
+      </SidebarMenu>
+    </SidebarGroup>
+  )
+}
+

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -1,0 +1,102 @@
+"use client"
+
+import {
+  BadgeCheck,
+  Bell,
+  ChevronsUpDown,
+  CreditCard,
+  LogOut,
+  Sparkles,
+} from "lucide-react"
+
+import Avatar from "@/components/avatar"
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from "@/components/ui/sidebar"
+
+export function NavUser({
+  user,
+}: {
+  user: {
+    name: string
+    email: string
+    avatar: string
+  }
+}) {
+  useSidebar()
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger>
+            <SidebarMenuButton
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            >
+              <Avatar name={user.name} />
+              <div className="grid flex-1 text-left text-sm leading-tight">
+                <span className="truncate font-medium">{user.name}</span>
+                <span className="truncate text-xs">{user.email}</span>
+              </div>
+              <ChevronsUpDown className="ml-auto size-4" />
+            </SidebarMenuButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="min-w-56 rounded-lg"
+            style={{ position: "absolute" }}
+          >
+            <DropdownMenuLabel className="p-0 font-normal">
+              <div className="flex items-center gap-2 px-1 py-1.5 text-left text-sm">
+                <Avatar name={user.name} />
+                <div className="grid flex-1 text-left text-sm leading-tight">
+                  <span className="truncate font-medium">{user.name}</span>
+                  <span className="truncate text-xs">{user.email}</span>
+                </div>
+              </div>
+            </DropdownMenuLabel>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuItem>
+                <Sparkles />
+                Upgrade to Pro
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuGroup>
+              <DropdownMenuItem>
+                <BadgeCheck />
+                Account
+              </DropdownMenuItem>
+              <DropdownMenuItem>
+                <CreditCard />
+                Billing
+              </DropdownMenuItem>
+              <DropdownMenuItem>
+                <Bell />
+                Notifications
+              </DropdownMenuItem>
+            </DropdownMenuGroup>
+            <DropdownMenuSeparator />
+            <DropdownMenuItem>
+              <LogOut />
+              Log out
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}
+

--- a/apps/web/src/components/team-switcher.tsx
+++ b/apps/web/src/components/team-switcher.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import * as React from "react"
+import { ChevronsUpDown, Plus } from "lucide-react"
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  useSidebar,
+} from "@/components/ui/sidebar"
+
+export function TeamSwitcher({
+  teams,
+}: {
+  teams: {
+    name: string
+    logo: React.ElementType
+    plan: string
+  }[]
+}) {
+  useSidebar()
+  const [activeTeam, setActiveTeam] = React.useState(teams[0])
+
+  if (!activeTeam) {
+    return null
+  }
+
+  return (
+    <SidebarMenu>
+      <SidebarMenuItem>
+        <DropdownMenu>
+          <DropdownMenuTrigger>
+            <SidebarMenuButton
+              className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
+            >
+              <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg">
+                <activeTeam.logo className="size-4" />
+              </div>
+              <div className="grid flex-1 text-left text-sm leading-tight">
+                <span className="truncate font-medium">{activeTeam.name}</span>
+                <span className="truncate text-xs">{activeTeam.plan}</span>
+              </div>
+              <ChevronsUpDown className="ml-auto" />
+            </SidebarMenuButton>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent
+            className="min-w-56 rounded-lg"
+            style={{ position: "absolute" }}
+          >
+            <DropdownMenuLabel className="text-muted-foreground text-xs">
+              Teams
+            </DropdownMenuLabel>
+            {teams.map((team, index) => (
+              <DropdownMenuItem
+                key={team.name}
+                onClick={() => setActiveTeam(team)}
+                className="gap-2 p-2"
+              >
+                <div className="flex size-6 items-center justify-center rounded-md border">
+                  <team.logo className="size-3.5 shrink-0" />
+                </div>
+                {team.name}
+                <DropdownMenuShortcut>⌘{index + 1}</DropdownMenuShortcut>
+              </DropdownMenuItem>
+            ))}
+            <DropdownMenuSeparator />
+            <DropdownMenuItem className="gap-2 p-2">
+              <div className="flex size-6 items-center justify-center rounded-md border bg-transparent">
+                <Plus className="size-4" />
+              </div>
+              <div className="text-muted-foreground font-medium">Add team</div>
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+      </SidebarMenuItem>
+    </SidebarMenu>
+  )
+}
+

--- a/apps/web/src/components/ui/collapsible.tsx
+++ b/apps/web/src/components/ui/collapsible.tsx
@@ -1,0 +1,57 @@
+import * as React from "react"
+
+export interface CollapsibleProps {
+  defaultOpen?: boolean
+  children: React.ReactNode
+  asChild?: boolean
+  className?: string
+}
+
+const CollapsibleContext = React.createContext<{
+  open: boolean
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>
+} | null>(null)
+
+export function Collapsible({
+  defaultOpen,
+  children,
+  className,
+}: CollapsibleProps & React.HTMLAttributes<HTMLDivElement>) {
+  const [open, setOpen] = React.useState(!!defaultOpen)
+  return (
+    <CollapsibleContext.Provider value={{ open, setOpen }}>
+      <div data-state={open ? "open" : "closed"} className={className}>
+        {children}
+      </div>
+    </CollapsibleContext.Provider>
+  )
+}
+
+export const CollapsibleTrigger = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+  ({ onClick, ...props }, ref) => {
+    const context = React.useContext(CollapsibleContext)
+    if (!context) return null
+    const { open, setOpen } = context
+    return (
+      <button
+        ref={ref}
+        onClick={(e) => {
+          setOpen(!open)
+          onClick?.(e)
+        }}
+        {...props}
+      />
+    )
+  }
+)
+
+export const CollapsibleContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  (props, ref) => {
+    const context = React.useContext(CollapsibleContext)
+    if (!context) return null
+    const { open } = context
+    if (!open) return null
+    return <div ref={ref} {...props} />
+  }
+)
+

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,85 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+const DropdownContext = React.createContext<{
+  open: boolean
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>
+} | null>(null)
+
+export function DropdownMenu({ children }: { children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false)
+  return (
+    <DropdownContext.Provider value={{ open, setOpen }}>
+      <div className="relative inline-block">{children}</div>
+    </DropdownContext.Provider>
+  )
+}
+
+export const DropdownMenuTrigger = React.forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(
+  ({ onClick, ...props }, ref) => {
+    const ctx = React.useContext(DropdownContext)
+    if (!ctx) return null
+    const { open, setOpen } = ctx
+    return (
+      <button
+        ref={ref}
+        onClick={(e) => {
+          setOpen(!open)
+          onClick?.(e)
+        }}
+        {...props}
+      />
+    )
+  }
+)
+
+export const DropdownMenuContent = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => {
+    const ctx = React.useContext(DropdownContext)
+    if (!ctx) return null
+    const { open } = ctx
+    if (!open) return null
+    return (
+      <div
+        ref={ref}
+        className={cn(
+          "absolute z-50 mt-2 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 shadow-md",
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+)
+
+export const DropdownMenuItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div
+      ref={ref}
+      className={cn(
+        "flex cursor-pointer select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent",
+        className
+      )}
+      {...props}
+    />
+  )
+)
+
+export const DropdownMenuSeparator = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("-mx-1 my-1 h-px bg-border", className)} {...props} />
+  )
+)
+
+export const DropdownMenuLabel = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => (
+    <div ref={ref} className={cn("px-2 py-1.5 text-sm font-semibold", className)} {...props} />
+  )
+)
+
+export const DropdownMenuGroup = ({ children }: { children: React.ReactNode }) => <div>{children}</div>
+
+export const DropdownMenuShortcut = ({ children }: { children: React.ReactNode }) => (
+  <span className="ml-auto text-xs tracking-widest opacity-60">{children}</span>
+)
+

--- a/apps/web/src/components/ui/separator.tsx
+++ b/apps/web/src/components/ui/separator.tsx
@@ -1,0 +1,26 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+export interface SeparatorProps extends React.HTMLAttributes<HTMLDivElement> {
+  orientation?: "horizontal" | "vertical"
+}
+
+export function Separator({
+  className,
+  orientation = "horizontal",
+  ...props
+}: SeparatorProps) {
+  return (
+    <div
+      role="separator"
+      aria-orientation={orientation}
+      className={cn(
+        "bg-border shrink-0",
+        orientation === "vertical" ? "w-px h-full" : "h-px w-full",
+        className
+      )}
+      {...props}
+    />
+  )
+}

--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -1,0 +1,220 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cn } from "@/lib/utils"
+
+interface SidebarContextValue {
+  collapsed: boolean
+  toggle: () => void
+  isMobile: boolean
+}
+
+const SidebarContext = React.createContext<SidebarContextValue | undefined>(
+  undefined
+)
+
+export function useSidebar() {
+  const ctx = React.useContext(SidebarContext)
+  if (!ctx) {
+    throw new Error("useSidebar must be used within a SidebarProvider")
+  }
+  return ctx
+}
+
+export function SidebarProvider({ children }: { children: React.ReactNode }) {
+  const [collapsed, setCollapsed] = React.useState(false)
+  const [isMobile, setIsMobile] = React.useState(false)
+
+  React.useEffect(() => {
+    const handleResize = () => setIsMobile(window.innerWidth < 768)
+    handleResize()
+    window.addEventListener("resize", handleResize)
+    return () => window.removeEventListener("resize", handleResize)
+  }, [])
+
+  const toggle = React.useCallback(() => setCollapsed((c) => !c), [])
+
+  return (
+    <SidebarContext.Provider value={{ collapsed, toggle, isMobile }}>
+      {children}
+    </SidebarContext.Provider>
+  )
+}
+
+export interface SidebarProps extends React.HTMLAttributes<HTMLDivElement> {
+  collapsible?: string
+}
+
+export const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
+  ({ className, collapsible, ...props }, ref) => {
+    const { collapsed } = useSidebar()
+    return (
+      <aside
+        ref={ref}
+        className={cn(
+          "bg-background border-r flex flex-col transition-all",
+          collapsed ? "w-14" : "w-60",
+          className
+        )}
+        data-collapsible={collapsible}
+        {...props}
+      />
+    )
+  }
+)
+Sidebar.displayName = "Sidebar"
+
+export function SidebarHeader({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("border-b p-2", className)} {...props} />
+}
+
+export function SidebarContent({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex-1 overflow-y-auto p-2", className)} {...props} />
+}
+
+export function SidebarFooter({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("border-t p-2", className)} {...props} />
+}
+
+export function SidebarRail({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("hidden", className)} {...props} />
+}
+
+export function SidebarInset({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("flex flex-col flex-1", className)} {...props} />
+}
+
+export function SidebarTrigger({
+  className,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  const { toggle } = useSidebar()
+  return (
+    <button
+      type="button"
+      onClick={toggle}
+      className={cn("h-8 w-8 flex items-center justify-center", className)}
+      {...props}
+    >
+      {props.children}
+    </button>
+  )
+}
+
+export function SidebarGroup({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("mb-4", className)} {...props} />
+}
+
+export function SidebarGroupLabel({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div className={cn("px-2 py-2 text-sm font-medium", className)} {...props} />
+  )
+}
+
+export function SidebarMenu({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLUListElement>) {
+  return <ul className={cn("grid gap-1 px-2", className)} {...props} />
+}
+
+export function SidebarMenuItem({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLLIElement>) {
+  return <li className={className} {...props} />
+}
+
+export interface SidebarMenuButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean
+}
+
+export const SidebarMenuButton = React.forwardRef<
+  HTMLButtonElement,
+  SidebarMenuButtonProps
+>(({ className, asChild, ...props }, ref) => {
+  const Comp = asChild ? Slot : "button"
+  return (
+    <Comp
+      ref={ref}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-accent",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+
+export function SidebarMenuSub({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLUListElement>) {
+  return <ul className={cn("ml-4 grid gap-1", className)} {...props} />
+}
+
+export function SidebarMenuSubItem({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLLIElement>) {
+  return <li className={className} {...props} />
+}
+
+export interface SidebarMenuSubButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  asChild?: boolean
+}
+
+export const SidebarMenuSubButton = React.forwardRef<
+  HTMLButtonElement,
+  SidebarMenuSubButtonProps
+>(({ className, asChild, ...props }, ref) => {
+  const Comp = asChild ? Slot : "button"
+  return (
+    <Comp
+      ref={ref}
+      className={cn(
+        "flex w-full items-center gap-2 rounded-md px-2 py-2 text-sm hover:bg-accent",
+        className
+      )}
+      {...props}
+    />
+  )
+})
+
+export function SidebarMenuAction({
+  className,
+  ...props
+}: React.ButtonHTMLAttributes<HTMLButtonElement>) {
+  return (
+    <button
+      className={cn(
+        "flex items-center rounded-md p-2 text-muted-foreground hover:bg-accent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+


### PR DESCRIPTION
## Summary
- integrate shadcn sidebar block components
- update app layout to use new sidebar
- implement minimal shadcn-style UI primitives

## Testing
- `pnpm --filter web lint`
- `pnpm --filter web build`


------
https://chatgpt.com/codex/tasks/task_e_685095f1ad948329877ca016be89a9c5