### PR TITLE
Fix doctor route on GitHub Pages

### DIFF
--- a/apps/web/404.html
+++ b/apps/web/404.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Reverse Healthcare</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -14,4 +14,12 @@ export default defineConfig({
       '@': path.resolve(__dirname, 'src'),
     },
   },
+  build: {
+    rollupOptions: {
+      input: {
+        main: path.resolve(__dirname, 'index.html'),
+        notFound: path.resolve(__dirname, '404.html'),
+      },
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add a `404.html` fallback so GitHub Pages keeps SPA routes
- include the `404.html` file in the Vite build

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6850a4b85f1c8329a6958ca4d5c305fd