### PR TITLE
Set rectangular card layout as default on wide screens

### DIFF
--- a/apps/web/src/components/home-dashboard.tsx
+++ b/apps/web/src/components/home-dashboard.tsx
@@ -40,6 +40,9 @@ export default function HomeDashboard({
       if (stored) {
         return stored
       }
+      if (window.innerWidth >= 1920 && window.innerHeight >= 1080) {
+        return 'rect'
+      }
     }
     return 'square'
   })


### PR DESCRIPTION
## Summary
- default to rectangular dashboard cards when screen is at least 1920x1080

## Testing
- `pnpm lint`
- `pnpm test` *(fails: no test script found)*

------
https://chatgpt.com/codex/tasks/task_e_6850a99211cc83299ab2aec6c0ad0fda