### PR TITLE
feat(web): collapse sidebar on mobile by default

### DIFF
--- a/apps/web/src/components/ui/sidebar.tsx
+++ b/apps/web/src/components/ui/sidebar.tsx
@@ -21,12 +21,11 @@ export function useSidebar() {
 }
 
 export function SidebarProvider({ children }: { children: React.ReactNode }) {
-  const [collapsed, setCollapsed] = React.useState(false)
-  const [isMobile, setIsMobile] = React.useState(false)
+  const [collapsed, setCollapsed] = React.useState(() => window.innerWidth < 768)
+  const [isMobile, setIsMobile] = React.useState(() => window.innerWidth < 768)
 
   React.useEffect(() => {
     const handleResize = () => setIsMobile(window.innerWidth < 768)
-    handleResize()
     window.addEventListener("resize", handleResize)
     return () => window.removeEventListener("resize", handleResize)
   }, [])


### PR DESCRIPTION
## Summary
- default sidebar state to collapsed on mobile screen widths

## Testing
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_6859d529bd248329942037cc44f23f59