### PR TITLE
Fix collapsed sidebar icon-only view

### DIFF
--- a/apps/web/src/components/nav-main.tsx
+++ b/apps/web/src/components/nav-main.tsx
@@ -16,6 +16,7 @@ import {
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
+  useSidebar,
 } from "@/components/ui/sidebar"
 
 export function NavMain({
@@ -32,6 +33,7 @@ export function NavMain({
     }[]
   }[]
 }) {
+  const { collapsed } = useSidebar()
   return (
     <SidebarGroup>
       <SidebarGroupLabel>Platform</SidebarGroupLabel>
@@ -46,23 +48,27 @@ export function NavMain({
               <CollapsibleTrigger>
                 <SidebarMenuButton title={item.title}>
                   {item.icon && <item.icon className="size-4" />}
-                  <span>{item.title}</span>
-                  <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+                  {!collapsed && <span>{item.title}</span>}
+                  {!collapsed && (
+                    <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
+                  )}
                 </SidebarMenuButton>
               </CollapsibleTrigger>
-              <CollapsibleContent>
-                <SidebarMenuSub>
-                  {item.items?.map((subItem) => (
-                    <SidebarMenuSubItem key={subItem.title}>
-                      <SidebarMenuSubButton>
-                        <a href={subItem.url}>
-                          <span>{subItem.title}</span>
-                        </a>
-                      </SidebarMenuSubButton>
-                    </SidebarMenuSubItem>
-                  ))}
-                </SidebarMenuSub>
-              </CollapsibleContent>
+              {!collapsed && (
+                <CollapsibleContent>
+                  <SidebarMenuSub>
+                    {item.items?.map((subItem) => (
+                      <SidebarMenuSubItem key={subItem.title}>
+                        <SidebarMenuSubButton>
+                          <a href={subItem.url}>
+                            <span>{subItem.title}</span>
+                          </a>
+                        </SidebarMenuSubButton>
+                      </SidebarMenuSubItem>
+                    ))}
+                  </SidebarMenuSub>
+                </CollapsibleContent>
+              )}
             </SidebarMenuItem>
           </Collapsible>
         ))}

--- a/apps/web/src/components/nav-projects.tsx
+++ b/apps/web/src/components/nav-projects.tsx
@@ -34,7 +34,7 @@ export function NavProjects({
     icon: LucideIcon
   }[]
 }) {
-  useSidebar()
+  const { collapsed } = useSidebar()
 
   return (
     <SidebarGroup className="group-data-[collapsible=icon]:hidden">
@@ -45,7 +45,7 @@ export function NavProjects({
             <SidebarMenuButton>
               <a href={item.url}>
                 <item.icon className="size-4" />
-                <span>{item.name}</span>
+                {!collapsed && <span>{item.name}</span>}
               </a>
             </SidebarMenuButton>
             <DropdownMenu>
@@ -79,7 +79,7 @@ export function NavProjects({
         <SidebarMenuItem>
           <SidebarMenuButton className="text-sidebar-foreground/70">
             <MoreHorizontal className="size-4 text-sidebar-foreground/70" />
-            <span>More</span>
+            {!collapsed && <span>More</span>}
           </SidebarMenuButton>
         </SidebarMenuItem>
       </SidebarMenu>

--- a/apps/web/src/components/nav-user.tsx
+++ b/apps/web/src/components/nav-user.tsx
@@ -35,7 +35,7 @@ export function NavUser({
     avatar: string
   }
 }) {
-  useSidebar()
+  const { collapsed } = useSidebar()
 
   return (
     <SidebarMenu>
@@ -46,11 +46,13 @@ export function NavUser({
               className="data-[state=open]:bg-sidebar-accent data-[state=open]:text-sidebar-accent-foreground"
             >
               <Avatar name={user.name} />
-              <div className="grid flex-1 text-left text-sm leading-tight">
-                <span className="truncate font-medium">{user.name}</span>
-                <span className="truncate text-xs">{user.email}</span>
-              </div>
-              <ChevronsUpDown className="ml-auto size-4" />
+              {!collapsed && (
+                <div className="grid flex-1 text-left text-sm leading-tight">
+                  <span className="truncate font-medium">{user.name}</span>
+                  <span className="truncate text-xs">{user.email}</span>
+                </div>
+              )}
+              {!collapsed && <ChevronsUpDown className="ml-auto size-4" />}
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent

--- a/apps/web/src/components/team-switcher.tsx
+++ b/apps/web/src/components/team-switcher.tsx
@@ -28,7 +28,7 @@ export function TeamSwitcher({
     plan: string
   }[]
 }) {
-  useSidebar()
+  const { collapsed } = useSidebar()
   const [activeTeam, setActiveTeam] = React.useState(teams[0])
 
   if (!activeTeam) {
@@ -46,11 +46,13 @@ export function TeamSwitcher({
               <div className="bg-sidebar-primary text-sidebar-primary-foreground flex aspect-square size-8 items-center justify-center rounded-lg">
                 <activeTeam.logo className="size-4" />
               </div>
-              <div className="grid flex-1 text-left text-sm leading-tight">
-                <span className="truncate font-medium">{activeTeam.name}</span>
-                <span className="truncate text-xs">{activeTeam.plan}</span>
-              </div>
-              <ChevronsUpDown className="ml-auto" />
+              {!collapsed && (
+                <div className="grid flex-1 text-left text-sm leading-tight">
+                  <span className="truncate font-medium">{activeTeam.name}</span>
+                  <span className="truncate text-xs">{activeTeam.plan}</span>
+                </div>
+              )}
+              {!collapsed && <ChevronsUpDown className="ml-auto" />}
             </SidebarMenuButton>
           </DropdownMenuTrigger>
           <DropdownMenuContent


### PR DESCRIPTION
## Summary
- hide text in team switcher when the sidebar is collapsed
- collapse nav main items to icons
- collapse nav projects menu
- collapse nav user menu

## Testing
- `pnpm --filter web lint`

------
https://chatgpt.com/codex/tasks/task_e_6859d5588e008329b18fc5cc352fb91b