### PR TITLE
Fix sidebar toggle layering

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -53,7 +53,7 @@ function App() {
           <SidebarInset>
           <div className="p-2 border-b flex justify-between items-center">
             <div className="flex items-center gap-2">
-              <SidebarTrigger className="md:hidden -ml-1">
+              <SidebarTrigger className="relative z-10 md:hidden -ml-1">
                 <Menu className="h-4 w-4" />
               </SidebarTrigger>
               <Separator orientation="vertical" className="mr-2 h-4" />


### PR DESCRIPTION
## Summary
- ensure the sidebar hamburger toggle renders above the collapsed sidebar

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_6859d5c8c05c83299e1de3588f8887f8